### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,11 @@ ENV EULA false
 
 # Add minecraft user
 RUN groupadd -g 1001 minecraft && \
-    useradd -u 1001 -g minecraft minecraft
-RUN mkdir -p /minecraft
-RUN chown -R 1001:1001 /minecraft
+    useradd -u 1001 -g minecraft minecraft && \
+    mkdir -p /minecraft && \
+    chown -R 1001:1001 /minecraft
 
 USER minecraft
-
-VOLUME ["/minecraft"]
 WORKDIR /minecraft
 
 # Download Minecraft and add entrypoint
@@ -21,5 +19,3 @@ COPY --chown=minecraft:minecraft /scripts/entrypoint.sh .
 # Start
 EXPOSE 25565
 ENTRYPOINT ["./entrypoint.sh"]
-
-


### PR DESCRIPTION
This change reduces the layers. Each run command creates a new layer. It's a common practice to reduce layers.

See:
- https://medium.com/@gdiener/how-to-build-a-smaller-docker-image-76779e18d48a
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
- https://learnk8s.io/blog/smaller-docker-images

Also removed the volume from the docker file. It will create anonymous volumes if not bind to any named volume at runtime. Btw. making the whole minecraft directory a volume won't let you update the server jar easily by updating the image because the content of the volume won't replaced.

See:
- https://boxboat.com/2017/01/23/volumes-and-dockerfiles-dont-mix/
- https://runnable.com/blog/9-common-dockerfile-mistakes