### PR TITLE
WIP: Fix bug with empty or non existing /conf folder

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-cd /minecraft/data
 
 # Check if directory exists and if files are present
-if ! ls -1qA $DIR | grep -q . ; then
-        echo "Copying files from /minecraft/conf/ to /minecraft/data"
-	# Copy all not already existing config files to the data folder
+if ls -1qA  /minecraft/data | grep -q . ; then
+        echo "Copying files from /minecraft/conf/ to /minecraft/conf"
+        # Copy all not already existing config files to the main folder
         cp -n /minecraft/conf/* .
+else
+        echo "Skip copying files..."
 fi
 
 echo "eula=$EULA" >> eula.txt
 java -jar -Xmx$MAX_MEMORY -Xms$MIN_MEMORY -jar /minecraft/server.jar nogui
+~                                                                                                                                                                                                                                                     
+~                                                                                                                                                                                                                                                     
+~                                                                               

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,13 +4,12 @@
 if ls -1qA  /minecraft/data | grep -q . ; then
         echo "Copying files from /minecraft/conf/ to /minecraft/conf"
         # Copy all not already existing config files to the main folder
-        cp -n /minecraft/conf/* .
+        cp -n /minecraft/conf/* /minecraft/data
 else
         echo "Skip copying files..."
 fi
 
+cd /minecraft/data
 echo "eula=$EULA" >> eula.txt
 java -jar -Xmx$MAX_MEMORY -Xms$MIN_MEMORY -jar /minecraft/server.jar nogui
-~                                                                                                                                                                                                                                                     
-~                                                                                                                                                                                                                                                     
-~                                                                               
+

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#cd /minecraft/data
-#Copies all non existing confi files to the data folder
+cd /minecraft/data
 
 # Check if directory exists and if files are present
 if ! ls -1qA $DIR | grep -q . ; then
-        echo "Copying files from /minecraft/conf/ ..."
+        echo "Copying files from /minecraft/conf/ to /minecraft/data"
+	# Copy all not already existing config files to the data folder
         cp -n /minecraft/conf/* .
 fi
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-cd /minecraft/data
 #Copies all non existing confi files to the data folder
-cp -n /minecraft/conf/* .
+
+
+if [ "$(ls -A '/minecraft/conf')" ]; then
+	cp -n /minecraft/conf/* .
+fi
+
 echo "eula=$EULA" >> eula.txt
 java -jar -Xmx$MAX_MEMORY -Xms$MIN_MEMORY -jar /minecraft/server.jar nogui

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+#cd /minecraft/data
 #Copies all non existing confi files to the data folder
 
-
-if [ "$(ls -A '/minecraft/conf')" ]; then
-	cp -n /minecraft/conf/* .
+# Check if directory exists and if files are present
+if ! ls -1qA $DIR | grep -q . ; then
+        echo "Copying files from /minecraft/conf/ ..."
+        cp -n /minecraft/conf/* .
 fi
 
 echo "eula=$EULA" >> eula.txt


### PR DESCRIPTION
The recent pull request added the possibility to mount config files in the `/minecraft/conf/` folder. 
These files will be copied on start-up using  `cp -n /minecraft/conf/* .`.

This leads to the following error if the directory does not exist or if it is empty.
```
mcserver-git     | cp: cannot stat '/minecraft/conf/*': No such file or directory
mcserver-git     | ./entrypoint.sh: line 5: eula.txt: Permission denied
```
This pull requests adds an empty check to `entrypoint.sh` that only executes that line if the directory exists and is non empty.